### PR TITLE
Prevent loading of files that are not directly located in the plugins folder

### DIFF
--- a/src/main/java/com/rylinaux/plugman/command/LoadCommand.java
+++ b/src/main/java/com/rylinaux/plugman/command/LoadCommand.java
@@ -97,10 +97,7 @@ public class LoadCommand extends AbstractCommand {
         }
 
         for (int i = 1; i < args.length; i++) {
-            String arg = args[i];
-            while (arg.contains("../"))
-                arg = arg.replace("../", "");
-            args[i] = arg;
+            args[i] = args[i].replaceAll("[/\\\\]", "");
         }
 
         Plugin potential = PluginUtil.getPluginByName(args, 1);

--- a/src/main/java/me/entity303/plugmanbungee/commands/cmd/LoadCommand.java
+++ b/src/main/java/me/entity303/plugmanbungee/commands/cmd/LoadCommand.java
@@ -27,15 +27,12 @@ public class LoadCommand {
             return;
         }
 
-        String arg = args[0];
-        while (arg.contains("../"))
-            arg = arg.replace("../", "");
-        args[0] = arg;
+        String filename = args[0].replaceAll("[/\\\\]", "");
 
-        File file = new File("plugins", args[0] + ".jar");
+        File file = new File("plugins", filename + ".jar");
 
         if (!file.exists()) {
-            this.sendMessage(sender, "§cEs gibt keine Plugin-Datei mit dem Namen §4" + args[0] + "§c!");
+            this.sendMessage(sender, "§cEs gibt keine Plugin-Datei mit dem Namen §4" + filename + "§c!");
             return;
         }
 


### PR DESCRIPTION
The previous fix did not fully resolve the issue because it still allowed loading plugins from subdirectories of the plugins folder (e.g. plugins/something/something/test.jar).
Additionally, it didn't fix the issue at all if the server is running on Windows, since Java on Windows will also accept backslashes (\) as directory separator.