### PR TITLE
Use classloader to identify plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.rylinaux</groupId>
     <artifactId>PlugMan</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
     <packaging>jar</packaging>
 
     <name>PlugMan</name>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: PlugManX
 main: com.rylinaux.plugman.PlugMan
-version: 2.3.0
+version: 2.3.1
 description: Plugin manager for Bukkit servers
 authors: [rylinaux, Entity303]
 api-version: 1.13


### PR DESCRIPTION
## The problem
Some developers prefer to directly register their plugin commands using [CommandMap#register](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/command/CommandMap.html#register(java.lang.String,org.bukkit.command.Command)) directly, instead of registering it in `plugin.yml` and then calling `getCommand("<command>").setExecutor(<main>)`, which will register the commands correctly in the command list, but the current Plugman code will not find these plugins if the fallback (prefix) is not the plugin name.

## The solution
With this PR, I implement the use of PluginClassLoader, which is responsible for loading plugin classes into memory, including plugin commands. However, this object also saves the plugin it loaded. Thus, each JavaPlugin loaded on the server has its own PluginClassLoader, allowing to identify the plugin responsible for each command registered on the server.

## Why not just use ClassLoader?
When you look at the code, you will see that I also kept checking for the fallback of the command. It's because during my testing, some plugins (like Vault) don't use PluginClassLoader to load their classes. So, using these two methods, we can find any plugin responsible for a specific command.