### PR TITLE
Fix compilation against PlugMan-Paper

### DIFF
--- a/plugman-assembly/pom.xml
+++ b/plugman-assembly/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.rylinaux</groupId>
         <artifactId>PlugManX</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugman-bukkit/pom.xml
+++ b/plugman-bukkit/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.rylinaux</groupId>
         <artifactId>PlugManX</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugman-bungee/pom.xml
+++ b/plugman-bungee/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.rylinaux</groupId>
         <artifactId>PlugManX</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugman-core/pom.xml
+++ b/plugman-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.rylinaux</groupId>
         <artifactId>PlugManX</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugman-paper/plugman-paper.iml
+++ b/plugman-paper/plugman-paper.iml
@@ -5,13 +5,9 @@
       <configuration>
         <autoDetectTypes>
           <platformType>PAPER</platformType>
-          <platformType>MCP</platformType>
         </autoDetectTypes>
         <projectReimportVersion>1</projectReimportVersion>
       </configuration>
     </facet>
-  </component>
-  <component name="McpModuleSettings">
-    <option name="srgType" value="SRG" />
   </component>
 </module>

--- a/plugman-paper/pom.xml
+++ b/plugman-paper/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.rylinaux</groupId>
         <artifactId>PlugManX</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -72,7 +72,7 @@
             <plugin>
                 <groupId>ca.bkaw</groupId>
                 <artifactId>paper-nms-maven-plugin</artifactId>
-                <version>1.4.9</version>
+                <version>1.4.10</version>
                 <executions>
                     <execution>
                         <phase>process-classes</phase>
@@ -97,14 +97,14 @@
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>
-            <version>1.21.7-R0.1-SNAPSHOT</version>
+            <version>1.21.8-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>ca.bkaw</groupId>
             <artifactId>paper-nms</artifactId>
-            <version>1.21.7-SNAPSHOT</version>
+            <version>1.21.8-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/plugman-velocity/pom.xml
+++ b/plugman-velocity/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.rylinaux</groupId>
         <artifactId>PlugManX</artifactId>
-        <version>3.0.2</version>
+        <version>3.0.3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/plugman-velocity/src/main/java/velocity/com/rylinaux/plugman/PlugManVelocity.java
+++ b/plugman-velocity/src/main/java/velocity/com/rylinaux/plugman/PlugManVelocity.java
@@ -52,7 +52,7 @@ import java.nio.file.Path;
 @Plugin(
         id = "plugmanvelocity",
         name = "PlugManVelocity",
-        version = "3.0.2",
+        version = "3.0.3",
         description = "Plugin manager for Velocity servers.",
         authors = {"rylinaux", "TestAccount666"}
 )

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.rylinaux</groupId>
     <artifactId>PlugManX</artifactId>
-    <version>3.0.2</version>
+    <version>3.0.3</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -57,7 +57,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <plugman.version>3.0.2</plugman.version>
+        <plugman.version>3.0.3</plugman.version>
         <manifold.version>2025.1.26</manifold.version>
         <jackson.version>2.13.5</jackson.version>
     </properties>


### PR DESCRIPTION
This is a simple PR that fixes compilation against PlugMan-Paper (which inevitably fixes compilation in general). All that was required was a few simple dependency bumps that were non-conflicting.