### PR TITLE
Fix: parse Minecraft 26.2 version with non-numeric segment

### DIFF
--- a/plugman-paper/src/main/java/paper/com/rylinaux/plugman/PaperInitializer.java
+++ b/plugman-paper/src/main/java/paper/com/rylinaux/plugman/PaperInitializer.java
@@ -81,16 +81,36 @@ public class PaperInitializer {
 
     /**
      * Returns the Minecraft version integer id. 1.20 -> 12000, 1.21.4 -> 12104, 26.1 -> 260100.
+     * <p>
+     * Paper reports the version id directly (e.g. "26.2"), but some builds append non-numeric
+     * metadata as extra segments like "26.2.build.3-alpha". Each segment is therefore parsed
+     * leniently, taking only its numeric prefix, so such versions still resolve correctly
+     * (26.2 -> 260200).
      */
     private int obtainVersion() {
         try {
             String[] versions = Bukkit.getMinecraftVersion().split("\\.");
-            return Integer.parseInt(versions[0]) * 10000
-                + (versions.length > 1 ? Integer.parseInt(versions[1]) : 0) * 100
-                + (versions.length > 2 ? Integer.parseInt(versions[2]) : 0);
+            int major = parseSegment(versions, 0);
+            int minor = parseSegment(versions, 1);
+            int patch = parseSegment(versions, 2);
+            return major * 10000 + minor * 100 + patch;
         } catch (Exception ignored) {
             plugin.getLogger().warning("Failed to obtain server version!");
         }
         return -1;
+    }
+
+    /**
+     * Leniently parses the numeric prefix of a version segment, returning 0 when the segment is
+     * missing or does not start with a digit.
+     */
+    private static int parseSegment(String[] segments, int index) {
+        if (index >= segments.length) return 0;
+
+        String segment = segments[index];
+        int end = 0;
+        while (end < segment.length() && Character.isDigit(segment.charAt(end))) end++;
+
+        return end == 0 ? 0 : Integer.parseInt(segment.substring(0, end));
     }
 }


### PR DESCRIPTION
## Problem

On Paper-based 26.2 builds, PlugManX can fail to enable with:

```
java.lang.NumberFormatException: For input string: "build"
    at paper.com.rylinaux.plugman.PaperInitializer.obtainVersion(...)
```

Paper reports a clean version id (e.g. `26.2`), but some builds append non-numeric metadata as extra segments (e.g. `26.2.build.3-alpha`). `obtainVersion()` calls `Integer.parseInt()` on each segment directly, so `parseInt("build")` blows up. Even where the exception is caught, it returns `-1`, which then falls back to the legacy `PaperPluginManager` instead of `ModernPaperPluginManager`.

## Fix

Parse each version segment leniently — take only its leading numeric prefix and ignore the rest. Non-numeric or missing segments count as `0`.

So `26.2` (and `26.2.build.3-alpha`) now resolves to `260200`, which is `>= 12005` and correctly selects `ModernPaperPluginManager`.

No behavior change for normal versions: `1.20 -> 12000`, `1.21.4 -> 12104`, `26.1 -> 260100`.

## Notes

Only touches `PaperInitializer#obtainVersion()`; adds a small private `parseSegment` helper. No new dependencies.
